### PR TITLE
chore: release v0.11.0

### DIFF
--- a/packages/agent-backend/opensdd.json
+++ b/packages/agent-backend/opensdd.json
@@ -4,7 +4,7 @@
   "depsDir": ".opensdd.deps",
   "publish": {
     "name": "agent-backend",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "description": "Client library and server daemon providing a unified API for agent-filesystem interaction within local or remote sandboxed workspaces",
     "specFormat": "0.1.0",
     "dependencies": []

--- a/packages/agent-backend/python/agent_backend/__init__.py
+++ b/packages/agent-backend/python/agent_backend/__init__.py
@@ -36,7 +36,7 @@ from agent_backend.types import (
     StatusChangeEvent,
 )
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 __all__ = [
     "ArrayOperationsLogger",

--- a/packages/agent-backend/python/pyproject.toml
+++ b/packages/agent-backend/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-backend"
-version = "0.10.0"
+version = "0.11.0"
 description = "A distributed, scalable filesystem backend for deep AI agents, backed by blob storage"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/agent-backend/typescript/package.json
+++ b/packages/agent-backend/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-backend",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A distributed filesystem backend for your AI agent in a single API, just like a database or storage system.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version to **v0.11.0** (minor)
- TypeScript `package.json` updated
- Python `pyproject.toml` + `__init__.py` synced

## Post-merge
After merging, manually trigger the **Publish Packages** workflow in GitHub Actions to publish to npm and PyPI.