### PR TITLE
fix: repair uv.lock corrupted by duplicate package blocks (main is red)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -565,32 +565,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx2"
-version = "2.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio", marker = "sys_platform != 'emscripten'" },
-    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
-    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
-    { name = "idna" },
-    { name = "truststore", marker = "sys_platform != 'emscripten'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
-]
-
-[[package]]
-name = "httpx2-jsfetch"
-version = "1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
-]
-
-[[package]]
 name = "id"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }


### PR DESCRIPTION
## Description

**`main` is currently broken.** `uv sync --locked` fails on a pristine checkout:

```
error: Failed to parse `uv.lock`
  Caused by: Dependency `httpx2-jsfetch` has missing `source` field
  but has more than one matching package
```

That's the exact command the python CI job runs, so the python job is failing on `main` and on every PR targeting it. This PR should go in ahead of anything else.

## Cause

Introduced by #84 (`openai` 2.46.0 → 3.2.0), which took `uv.lock` from **80 package blocks to 82**:

| commit | blocks | dupes |
|---|---:|---:|
| `e4e4760` (#83 mcp) | 80 | 0 |
| `6acc40c` (#84 openai) | 82 | **2** |
| `fe8318e` (#87, current main) | 82 | **2** |

The two extra blocks are byte-identical duplicates of `httpx2` and `httpx2-jsfetch`. uv cannot resolve a dependency reference that omits a `source` field when more than one package block matches that name — so uv's own parser rejects the lockfile Dependabot generated. This is a Dependabot lock-generation bug, not a bad merge by anyone.

## Fix

The minimum that restores a parseable lock: drop the exact-duplicate blocks. **26 deletions, 0 insertions.** Nothing is re-resolved, so every merged Dependabot PR keeps its intent — verified still pinned:

- `openai` 3.2.0 ✓
- `mcp` 2.0.0 ✓
- `ruff` 0.16.3 ✓
- `httpx2` 2.12.0, `httpx2-jsfetch` 1.0 ✓ (one copy each)

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## Testing

- `uv lock --check` — passes (parses *and* is current with `pyproject.toml`)
- `uv sync --locked` — exit 0, the CI command
- `ruff check` — clean
- `pytest` — 275 passed, 87.8% coverage

## Additional Notes

Worth watching: if Dependabot reopens or rebases a uv PR it may regenerate the same duplicate blocks. If this recurs, the pattern to check is `grep -c '^name = "httpx2"' uv.lock` returning more than 1.

I found this while resolving the merge conflicts on #81/#85/#86 — those are still outstanding and I'll follow up with them once this lands, since they all touch `uv.lock` or a lockfile and should rebase onto a repaired `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PuuXnKtesJk9g3BKypFbAt